### PR TITLE
Added canvas-to-blob package dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,6 +9,7 @@ Package.onUse(function (api) {
   api.versionsFrom('0.9.0');
   api.use('jquery', 'client');
   api.imply('jquery', 'client');
+  api.use('pdiniz:canvas-to-blob');
   api.addFiles([
     'cropper/dist/cropper.js',
     'cropper/dist/cropper.css'


### PR DESCRIPTION
I added a small dependency for the package on canvas-to-blob package. Currently:

> "Get a canvas drawn the cropped image.
> After then, you can display the canvas as an image directly, or use canvas.toDataURL to get a Data >URL, or use canvas.toBlob to get a blob and upload it to server with FormData if the browser supports >these APIs."

only works on Firefox and later versions of IE. This package is a meteor wrapper around blueimp's JavaScript-Canvas-to-Blob which brings the same functionality to the following browsers.

Desktop browsers
Google Chrome (see Chromium issue #67587)
Apple Safari 6.0+ (see Mozilla issue #648610)
Mozilla Firefox 4.0+
Microsoft Internet Explorer 10.0+

Mobile browsers
Apple Safari Mobile on iOS 6.0+
Google Chrome on iOS 6.0+
Google Chrome on Android 4.0+

I found myself having to import both packages every time i wanted to use the cropper package so I figured it would be a good idea to just add it as a dependency for the cropper app.
